### PR TITLE
Make options in TelegramConstructor optional

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -720,7 +720,7 @@ export interface TelegramConstructor {
    * @param token Bot token
    * @param options Telegram options
    */
-  new(token: string, options: TelegramOptions): Telegram;
+  new(token: string, options?: TelegramOptions): Telegram;
 }
 
 export interface TelegrafOptions {


### PR DESCRIPTION
As per documention [here](https://telegraf.js.org/#/?id=constructor1).

# Description

Makes second parameter to Telegram constructor optional as per [documentation](https://telegraf.js.org/#/?id=constructor1).

Fixes #630

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
